### PR TITLE
Countour_xyz produces inconsistent plots

### DIFF
--- a/R/plotting.r
+++ b/R/plotting.r
@@ -111,13 +111,17 @@ bins <- function( x , n_bins=30 , rm.na=TRUE , ... ) {
 }
 
 # just converts x,y,z lists of same length to a matrix for contour to plot
+# modified to be independent of the order in which vectors x and y are 
+# supplied and to accept rectangular, rather than square, data grids.
 contour_xyz <- function( x , y , z , ... ) {
-    ux <- unique(x)
-    uy <- unique(y)
-    n <- length(ux)
-    m <- matrix( z , nrow=n , ncol=n )
-    contour( ux , uy , m , ... )
+    df <- data.frame(x=x,y=y,z=z)
+    df <- df[order(y,x),]
+    ux <- unique(df[order(df$x),]$x) 
+    uy <- unique(df[order(df$y),]$y) 
+    m <- matrix( df$z , nrow=length(ux) , ncol=length(uy) )    
+   contour( ux , uy , m , ... )
 }
+
 
 # just converts inputs to form expected by image()
 image_xyz <- function( x , y , z , ... ) {


### PR DESCRIPTION
The existing version of contour_xyz(x,y,z) produces results that depend on the order of the vectors x and y. In particular, if the order of arguments is changed to contour_xyz(y,x,z) then the figure produced is the same but the axes labels are incorrect. 

It expects the data to be a square nXn grid with the vector x ordered from x_min to x_max, and then repeated n times, and the vector y to be ordered with n repeats of each element in y sequentially n times. If the order of the vectors x and y are switched (i.e. contour_xyz(y,x,z)) then the function produces a similar figure but with the axes labels flipped.

The revised code first orders the data and then performs the same contour call.

Here is code for a minimal example that shows output at issue and the output with the revised function.


-----R code -----
#Tidyverse is used to generate the data and make test plots, not in the modified contour_xyz function
library(rethinking)
library(tidyverse)

contour_xyz_new <- function( x , y , z , ... ) {
  df <- data.frame(x=x,y=y,z=z)
  df <- df[order(y,x),]
  ux <- unique(df[order(df$x),]$x) 
  uy <- unique(df[order(df$y),]$y) 
  m <- matrix( df$z , nrow=length(ux) , ncol=length(uy) )
  contour( ux , uy , m , ... )
} 

data=expand_grid(x=seq(from=100, to=110,length.out=100), y=seq(from=4, to=8,length.out=100))%>%
  mutate( posterior= dnorm(x,mean=105,sd=2) * dnorm(y,mean=7,sd=1)  ,
          posterior=posterior/sum(posterior))  

rethinking::contour_xyz(data$x,data$y,data$posterior)
rethinking::contour_xyz(data$y,data$x,data$posterior)

contour_xyz_new(data$x,data$y,data$posterior)
contour_xyz_new(data$y,data$x,data$posterior)

# we can also compare to the density plot of samples from the posterior

samples=sample_n(data,weight = posterior, size = 1e5,replace = TRUE) 

ggplot(data=samples, aes(x=x, y=y)) +
  geom_density_2d(bins=10) +
  xlim(100,110)+
  ylim(4,8)

ggplot(data=samples, aes(x=y, y=x)) +
  geom_density_2d(bins=10)  +
  ylim(100,110)+
  xlim(4,8)